### PR TITLE
Handle missing ratelimit status response headers from the GitHub API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,12 +9,12 @@ scalaVersion := "2.13.10"
 libraryDependencies ++= Seq(
   "com.madgag" %% "rate-limit-status" % "0.7",
   "com.typesafe.play" %% "play" % "2.8.18",
-  "com.squareup.okhttp3" % "okhttp" % "3.12.13",
+  "com.squareup.okhttp3" % "okhttp" % "3.14.9",
   "com.lihaoyi" %% "fastparse" % "2.3.3",
   "com.madgag" %% "scala-collection-plus" % "0.11",
   "com.madgag.scala-git" %% "scala-git" % "4.6",
   "com.madgag.scala-git" %% "scala-git-test" % "4.6" % Test,
-  "org.scalatest" %% "scalatest" % "3.2.14" % Test
+  "org.scalatest" %% "scalatest" % "3.2.15" % Test
 )
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.8.2

--- a/src/test/scala/com/madgag/scalagithub/ResponseMetaTest.scala
+++ b/src/test/scala/com/madgag/scalagithub/ResponseMetaTest.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Roberto Tyley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.madgag.scalagithub
+
+import okhttp3.Headers
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ResponseMetaTest extends AnyFlatSpec with Matchers {
+  it should "not crash if ratelimit state response headers are missing" in {
+    ResponseMeta.rateLimitStatusFrom(
+      Headers.of("nothing-useful", "whatever")
+    ) shouldBe None
+  }
+}


### PR DESCRIPTION
We're seeing `NumberFormatException`s like these in Prout's logs, not all the time, but sometimes several times a minute:

```
Jan 25 16:01:24 prout-bot app/web.1 [error] l.ScanScheduler - Scanning RepoId(guardian,support-frontend) failed
Jan 25 16:01:24 prout-bot app/web.1 java.lang.NumberFormatException: null
Jan 25 16:01:24 prout-bot app/web.1 	at java.base/java.lang.Integer.parseInt(Integer.java:614)
Jan 25 16:01:24 prout-bot app/web.1 	at java.base/java.lang.Integer.parseInt(Integer.java:770)
Jan 25 16:01:24 prout-bot app/web.1 	at scala.collection.StringOps$.toInt$extension(StringOps.scala:908)
Jan 25 16:01:24 prout-bot app/web.1 	at com.madgag.scalagithub.ResponseMeta$.rateLimitStatusFrom(GitHub.scala:64)
Jan 25 16:01:24 prout-bot app/web.1 	at com.madgag.scalagithub.ResponseMeta$.$anonfun$rateLimitFrom$2(GitHub.scala:74)
Jan 25 16:01:24 prout-bot app/web.1 	at scala.Option.map(Option.scala:242)
Jan 25 16:01:24 prout-bot app/web.1 	at com.madgag.scalagithub.ResponseMeta$.rateLimitFrom(GitHub.scala:74)
Jan 25 16:01:24 prout-bot app/web.1 	at com.madgag.scalagithub.ResponseMeta$.from(GitHub.scala:89)
Jan 25 16:01:24 prout-bot app/web.1 	at com.madgag.scalagithub.GitHub$.logAndGetMeta(GitHub.scala:115)
Jan 25 16:01:24 prout-bot app/web.1 	at com.madgag.scalagithub.GitHub.$anonfun$executeAndReadJson$1(GitHub.scala:394)
```

The code is trying to read the `X-RateLimit-Remaining` HTTP response header, which [_should_ be getting returned by the GitHub API](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#checking-your-rate-limit-status) but the `NumberFormatException: null` at [Integer.java:614](https://github.com/openjdk/jdk/blob/jdk-11%2B17/src/java.base/share/classes/java/lang/Integer.java#L613-L615) shows that the response header is not present (the OkHttp library returns a nullable string value when getting an http response header).

Side note: the message `NumberFormatException: null` has changed in later versions of Java - since JDK 17, the message would be `NumberFormatException: Cannot parse null string`:

* https://github.com/openjdk/jdk/commit/564011cff0667c6d34cf6aa46eedd11f2e01862b
* https://bugs.openjdk.org/browse/JDK-8261290
