### PR TITLE
Upgrade to OkHttp 4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val core = (project in file("core")).settings(
   libraryDependencies ++= Seq(
     "com.madgag" %% "rate-limit-status" % "0.7",
     "com.typesafe.play" %% "play" % "2.8.19",
-    "com.squareup.okhttp3" % "okhttp" % "3.14.9",
+    "com.squareup.okhttp3" % "okhttp" % "4.10.0",
     "com.lihaoyi" %% "fastparse" % "3.0.0",
     "com.madgag" %% "scala-collection-plus" % "0.11",
     "com.madgag.scala-git" %% "scala-git" % scalaGitVersion,

--- a/core/src/main/scala/com/madgag/scalagithub/GitHub.scala
+++ b/core/src/main/scala/com/madgag/scalagithub/GitHub.scala
@@ -20,7 +20,7 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 
 import java.time.Duration.ofHours
-import java.time.Instant
+import java.time.{Instant, ZonedDateTime}
 import java.util.concurrent.TimeUnit.SECONDS
 import com.madgag.okhttpscala._
 import com.madgag.ratelimitstatus.{QuotaUpdate, RateLimit}
@@ -29,7 +29,6 @@ import com.madgag.scalagithub.commands._
 import com.madgag.scalagithub.model._
 import okhttp3.Request.Builder
 import okhttp3._
-import okhttp3.internal.http.HttpDate
 import play.api.Logger
 import play.api.http.Status
 import play.api.http.Status._
@@ -39,7 +38,10 @@ import play.api.libs.json._
 import scala.jdk.CollectionConverters._
 import scala.concurrent.{Future, ExecutionContext => EC}
 import scala.language.implicitConversions
-import fastparse._, NoWhitespace._
+import fastparse._
+import NoWhitespace._
+
+import java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME
 
 case class Quota(
   consumed: Int,
@@ -73,7 +75,7 @@ object ResponseMeta {
     remaining = remaining.toInt,
     limit = limit.toInt,
     reset = Instant.ofEpochSecond(reset.toLong),
-    capturedAt = HttpDate.parse(date).toInstant
+    capturedAt = ZonedDateTime.parse(date, RFC_1123_DATE_TIME).toInstant
   ))
 
   def rateLimitFrom(response: Response): Quota = {

--- a/core/src/test/scala/com/madgag/scalagithub/ResponseMetaTest.scala
+++ b/core/src/test/scala/com/madgag/scalagithub/ResponseMetaTest.scala
@@ -17,13 +17,27 @@
 package com.madgag.scalagithub
 
 import okhttp3.Headers
+import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class ResponseMetaTest extends AnyFlatSpec with Matchers {
+import java.time.Instant
+
+class ResponseMetaTest extends AnyFlatSpec with Matchers with OptionValues {
   it should "not crash if ratelimit state response headers are missing" in {
     ResponseMeta.rateLimitStatusFrom(
       Headers.of("nothing-useful", "whatever")
     ) shouldBe None
+  }
+
+  it should "parse the Date header from a GitHub request" in {
+    ResponseMeta.rateLimitStatusFrom(
+      new Headers.Builder()
+        .add("date", "Thu, 02 Nov 2023 12:37:22 GMT")
+        .add("x-ratelimit-remaining", "58")
+        .add("x-ratelimit-limit", "60")
+        .add("x-ratelimit-reset", "1698932232")
+        .build()
+    ).value.quotaUpdate.capturedAt shouldBe Instant.parse("2023-11-02T12:37:22Z")
   }
 }


### PR DESCRIPTION
This upgrade was prompted by https://github.com/guardian/prout/pull/114, where @AshCorr noted that updating to OkHttp 4 was blocked by `play-git-hub`s use of OkHttp's internal `HttpDate` class.

Thankfully the `java.time` package offers the [`RFC_1123_DATE_TIME`](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#RFC_1123_DATE_TIME) date time formatter, which looks to be a good substitute for parsing the `Date` header returned by the GitHub API, so we can move `play-git-hub` on to the latest OkHttp!

