### PR TITLE
Bump Play to 3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val core = (project in file("core")).settings(
   libraryDependencies ++= Seq(
     "com.madgag" %% "rate-limit-status" % "0.7",
     "org.playframework" %% "play" % "3.0.0",
-    "com.squareup.okhttp3" % "okhttp" % "4.10.0",
+    "com.squareup.okhttp3" % "okhttp" % "4.12.0",
     "com.lihaoyi" %% "fastparse" % "3.0.0",
     "com.madgag" %% "scala-collection-plus" % "0.11",
     "com.madgag.scala-git" %% "scala-git" % scalaGitVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -15,11 +15,12 @@ lazy val core = (project in file("core")).settings(
   resolvers ++= Resolver.sonatypeOssRepos("releases"),
   libraryDependencies ++= Seq(
     "com.madgag" %% "rate-limit-status" % "0.7",
-    "com.typesafe.play" %% "play" % "2.8.19",
+    "org.playframework" %% "play" % "3.0.0",
     "com.squareup.okhttp3" % "okhttp" % "4.10.0",
     "com.lihaoyi" %% "fastparse" % "3.0.0",
     "com.madgag" %% "scala-collection-plus" % "0.11",
     "com.madgag.scala-git" %% "scala-git" % scalaGitVersion,
+    "joda-time" % "joda-time" % "2.12.5",
     scalaGitTest % Test,
     scalaTest % Test
   )

--- a/core/src/main/scala/com/madgag/github/Implicits.scala
+++ b/core/src/main/scala/com/madgag/github/Implicits.scala
@@ -16,16 +16,16 @@
 
 package com.madgag.github
 
-import akka.NotUsed
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Keep, Sink}
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Keep, Sink}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import scala.util.{Success, Try}
 
 object Implicits {
-  implicit class RichSource[T](s: akka.stream.scaladsl.Source[Seq[T], NotUsed]) {
+  implicit class RichSource[T](s: org.apache.pekko.stream.scaladsl.Source[Seq[T], NotUsed]) {
     def all()(implicit mat: Materializer): Future[Seq[T]] = s.toMat(Sink.reduce[Seq[T]](_ ++ _))(Keep.right).run()
   }
 

--- a/core/src/main/scala/com/madgag/scalagithub/GitHub.scala
+++ b/core/src/main/scala/com/madgag/scalagithub/GitHub.scala
@@ -16,8 +16,8 @@
 
 package com.madgag.scalagithub
 
-import akka.NotUsed
-import akka.stream.scaladsl.Source
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.scaladsl.Source
 
 import java.time.Duration.ofHours
 import java.time.{Instant, ZonedDateTime}

--- a/core/src/main/scala/com/madgag/scalagithub/model/Repo.scala
+++ b/core/src/main/scala/com/madgag/scalagithub/model/Repo.scala
@@ -16,8 +16,8 @@
 
 package com.madgag.scalagithub.model
 
-import akka.NotUsed
-import akka.stream.scaladsl.Source
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.scaladsl.Source
 import com.madgag.scalagithub.GitHub
 import com.madgag.scalagithub.GitHub.FR
 import com.madgag.scalagithub.commands._

--- a/testkit/src/main/scala/com/madgag/playgithub/testkit/RepoLifecycle.scala
+++ b/testkit/src/main/scala/com/madgag/playgithub/testkit/RepoLifecycle.scala
@@ -16,7 +16,7 @@
 
 package com.madgag.playgithub.testkit
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.madgag.github.Implicits.RichSource
 import com.madgag.scalagithub.GitHub
 import com.madgag.scalagithub.GitHub.FR

--- a/testkit/src/main/scala/com/madgag/playgithub/testkit/TestRepoCreation.scala
+++ b/testkit/src/main/scala/com/madgag/playgithub/testkit/TestRepoCreation.scala
@@ -16,7 +16,7 @@
 
 package com.madgag.playgithub.testkit
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.madgag.git.RichRepo
 import com.madgag.git.test.unpackRepo
 import com.madgag.github.Implicits._


### PR DESCRIPTION
### What does this change?

Bumps this library to be using Play 3.0, [this PR](https://github.com/guardian/prout/pull/114) is currently getting version conflicts from 2 different versions of play requesting a non-binary compatible dependency.

This PR doesn't include any changes to enable compiling to Scala 3.