### PR TITLE
Fix crash using fine grained access tokens

### DIFF
--- a/core/src/main/scala/com/madgag/scalagithub/GitHub.scala
+++ b/core/src/main/scala/com/madgag/scalagithub/GitHub.scala
@@ -87,8 +87,8 @@ object ResponseMeta {
   }
 
   def requestScopesFrom(response: Response) = RequestScopes(
-    response.header("X-OAuth-Scopes").split(',').map(_.trim).toSet,
-    response.header("X-Accepted-OAuth-Scopes").split(',').map(_.trim).toSet
+    Option(response.header("X-OAuth-Scopes")).map(v => v.split(',').map(_.trim).toSet).getOrElse(Set.empty),
+    Option(response.header("X-Accepted-OAuth-Scopes")).map(v => v.split(',').map(_.trim).toSet).getOrElse(Set.empty)
   )
 
   def linksFrom(response: Response): Seq[LinkTarget] = for {


### PR DESCRIPTION
Responses from requests made using fine grained access tokens don't have the `X-OAuth-Scopes` headers.

At the moment the library hard crashes trying to use one:

```
java.lang.NullPointerException
  at scala.collection.StringOps$.split$extension(StringOps.scala:836)
  at com.madgag.scalagithub.ResponseMeta$.requestScopesFrom(GitHub.scala:90)
  at com.madgag.scalagithub.ResponseMeta$.from(GitHub.scala:100)
  at com.madgag.scalagithub.GitHub$.logAndGetMeta(GitHub.scala:126)
  at com.madgag.scalagithub.GitHub.$anonfun$executeAndWrap$1(GitHub.scala:392)
  at com.madgag.okhttpscala.package$RickOkHttpClient$$anon$1.$anonfun$onResponse$1(package.scala:45)
  at scala.util.Try$.apply(Try.scala:210)
  at com.madgag.okhttpscala.package$RickOkHttpClient$$anon$1.onResponse(package.scala:45)
  at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
  at java.base/java.lang.Thread.run(Thread.java:829)
```

Context: I'm interested in setting up [Prout](https://github.com/guardian/prout) @rcpch so thought I'd try using a fine grained access token to only give it write access to PR comments and labels, not write access to the actual code. I still need to test whether I've actually managed to achieve this (setup in screenshot below) but since this is a general purpose library it's probably cool to support both types of token anyway.

![Screenshot from 2024-07-19 17-14-36](https://github.com/user-attachments/assets/3fbee909-4b63-4bc6-83e9-2b4508baca8c)

I guess this is a breaking change but I couldn't see anywhere within the library itself or within the guardian org where they were used (ie prout).