### PR TITLE
Use `x-access-token` for git `CredentialsProvider`

### DIFF
--- a/core/src/main/scala/com/madgag/scalagithub/GitHubCredentials.scala
+++ b/core/src/main/scala/com/madgag/scalagithub/GitHubCredentials.scala
@@ -60,5 +60,5 @@ case class GitHubCredentials(
   accessKey: String,
   okHttpClient: OkHttpClient
 ) {
-  lazy val git: CredentialsProvider = new UsernamePasswordCredentialsProvider(accessKey, "")
+  lazy val git: CredentialsProvider = new UsernamePasswordCredentialsProvider("x-access-token", accessKey)
 }


### PR DESCRIPTION
From https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation : 

> You can also use an installation access token to authenticate for HTTP-based Git access. Your app must have the "Contents" repository permission. You can then use the installation access token as the HTTP password. Replace TOKEN with the installation access token: git clone https://x-access-token:TOKEN@github.com/owner/repo.git.

...we are using GitHub Apps more and more, and need to be able to authenticate for Git clone/push operations.

Example of code already using this:

https://github.com/rtyley/gha-micropython-logic-capture-workflow/blob/92e0029e66144b19f5de7f69aa45339a2d05d0b4/worker/src/main/scala/com/madgag/micropython/logiccapture/worker/LogicCaptureWorker.scala#L27-L30

