### PR TITLE
Add support for getting the authenticated GitHub App

### DIFF
--- a/core/src/main/scala/com/madgag/scalagithub/GitHub.scala
+++ b/core/src/main/scala/com/madgag/scalagithub/GitHub.scala
@@ -314,6 +314,9 @@ class GitHub(ghCredentials: GitHubCredentials) {
   def getUser()(implicit ec: EC): Future[GitHubResponse[User]] =
     executeAndReadJson(addAuthAndCaching(new Builder().url(path("user"))))
 
+  def getAuthenticatedApp()(implicit ec: EC): Future[GitHubResponse[GitHubApp]] =
+    executeAndReadJson(addAuthAndCaching(new Builder().url(path("app"))))
+
   /**
    * https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-a-user
    */

--- a/core/src/main/scala/com/madgag/scalagithub/model/GitHubApp.scala
+++ b/core/src/main/scala/com/madgag/scalagithub/model/GitHubApp.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Roberto Tyley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.madgag.scalagithub.model
+
+import play.api.libs.json.Json
+
+import java.time.ZonedDateTime
+
+case class GitHubApp(
+  slug: String,
+  id: Long,
+  url: String,
+  html_url: String,
+  name: Option[String] = None,
+  created_at: Option[ZonedDateTime] = None
+)
+
+object GitHubApp {
+  implicit val readsGitHubApp = Json.reads[GitHubApp]
+}


### PR DESCRIPTION
In service of:

* https://github.com/guardian/prout/issues/137

...calling this API endpoint:

https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-the-authenticated-app
