### PR TITLE
Retry fetching `Ref`s during repo creation, to out-wait transient List-wrapping (`[]`) of GitHub responses

### DIFF
--- a/core/src/test/scala/com/madgag/scalagithub/GitHubWithPATAuthTest.scala
+++ b/core/src/test/scala/com/madgag/scalagithub/GitHubWithPATAuthTest.scala
@@ -33,8 +33,6 @@ object GitHubWithPATAuthTest extends IOSuite with OptionValues {
   type Res = GitHub
 
   def sharedResource : Resource[IO, Res] = for {
-    httpBackend <- HttpClientCatsBackend.resource[IO]()
-    dispatcher <- Dispatcher.parallel[IO]
     githubFactory <- GitHub.Factory()
     clientWithContext <- Resource.eval(githubFactory.accessWithUserToken(AccessToken(sys.env("PLAY_GIT_HUB_TEST_GITHUB_ACCESS_TOKEN"))))
   } yield clientWithContext.gitHub

--- a/testkit/src/main/scala/com/madgag/playgithub/testkit/TestRepoCreation.scala
+++ b/testkit/src/main/scala/com/madgag/playgithub/testkit/TestRepoCreation.scala
@@ -143,6 +143,7 @@ class TestRepoCreation(
 
   private def getRefDataFromGitHubApi(testGithubRepo: Repo, branchRef: Ref)(using GitHub): FR[model.Ref] =
     testGithubRepo.refs.get(branchRef): IO[GitHubResponse[model.Ref]]
+  .retryingOnErrors(retryPolicy, retryOnAllErrors(logRetry(s"get ${branchRef.getName}")))
 
   private def logRetry(detail: String): (Throwable, RetryDetails) => IO[Unit] = (_, retryDetails) =>
     IO.println(s"retrying '$detail' - delay so far=${retryDetails.cumulativeDelay.toSeconds}s")


### PR DESCRIPTION
This is a fix handling GitHub intermittently List-wrapping (`[]`) JSON API responses:

* https://github.com/rtyley/play-git-hub/issues/22

This is quite a constrained fix - it only adds retrying to the fetching of `Ref`s during Test Repo creation:

https://github.com/rtyley/play-git-hub/blob/ca7ab562ab32fd5ba94764a8f164a381143fb74c/testkit/src/main/scala/com/madgag/playgithub/testkit/TestRepoCreation.scala#L138-L140

...this is enough to get tests to pass on `play-git-hub`, but it may be that in the future we want to apply retrying more broadly to all GitHub `GET` requests.

## Alternative fix:

* https://github.com/rtyley/play-git-hub/pull/20

...but actually, we can apply _both_ fixes for the best of both worlds.
